### PR TITLE
Add cmake command to project setup instructions

### DIFF
--- a/Tutorials/CPP/README.md
+++ b/Tutorials/CPP/README.md
@@ -30,6 +30,7 @@ Clone or download the code to your work directory: `$home = path/to/files`
     - `cd $home`
     - `mkdir Build`
     - `cd Build`
+    - `cmake ..`
     - Run `make -j4`
         - It takes some time
         - You may replace the 4 with the number of cores on your machine


### PR DESCRIPTION
Adds missing `cmake` to `README.md`


---

Also to get my build to work I needed to change:

In: **`CMPSC_458_Fall_2025_Tutorials/Tutorials/CPP/Vendor/assimp/contrib/unzip/unzip.c`**, line **`1177`**

```
        s->pcrc_32_tab = get_crc_table();
```
to 
```
        s->pcrc_32_tab = (const unsigned long*)get_crc_table();
```
